### PR TITLE
replace explicit tuple constructor with tuple factory

### DIFF
--- a/csrc/utils.cpp
+++ b/csrc/utils.cpp
@@ -88,7 +88,7 @@ void segment_blocks(torch::Tensor layout, torch::Tensor idx, torch::Tensor scrat
     if(current[h] > 0)
       to_cat.push_back(scratch[h].slice(0, 0, current[h]));
   if(!to_cat.empty())
-    ret.push_back({max_width, torch::cat(to_cat)});
+    ret.push_back(std::make_tuple(max_width, torch::cat(to_cat)));
 }
 
 


### PR DESCRIPTION
This PR is fixes #31 which is about install error during building 'torch_blocksparse_cpp_utils' extension

I've done some research and found out that some C++ versions do not support such syntax of explicit tuple constructions according to these SO questions: [32084706](https://stackoverflow.com/questions/32084706/why-initialization-doesnt-work-for-tuple) and [12436586](https://stackoverflow.com/questions/12436586/tuple-vector-and-initializer-list).
After replacing explicit tuple constructor

https://github.com/ptillet/torch-blocksparse/blob/9aa94789f13ada713af36cfd8cca2fc9a7f6b79a/csrc/utils.cpp#L91

 with `std::make_tuple(max_width, torch::cat(to_cat))`

 I've successfully managed to build 'torch_blocksparse_cpp_utils' and hence to install torch_blocksparse.

I don't know if there is any issue with torch==1.7 compatibility or with my gcc version but I offer to make the building process independent from non-universal syntactic constructions.
