### PR TITLE
Possible fix for #34

### DIFF
--- a/torch_blocksparse/softmax.py
+++ b/torch_blocksparse/softmax.py
@@ -293,7 +293,7 @@ class _sparse_softmax(torch.autograd.Function):
 
         # run kernel
         time[0] = kernel(x, scale, lut, rpe, key_padding_mask, attn_mask,\
-                         num_blocks, maxlut,\
+                         num_blocks.item(), maxlut,\
                          x.stride(0),\
                          stride_zrpe, stride_hrpe, stride_srpe,\
                          stride_zkpm, stride_zattnm,\


### PR DESCRIPTION
num_blocks is expected to be int. When it's not int, data_ptr() is called in kernel.py that could overflow.
I'm not sure whether this is correct fix or the function should accept a buffer